### PR TITLE
Fix long text commands to timeout

### DIFF
--- a/migrations/20190521222304-update-poll-text-long.js
+++ b/migrations/20190521222304-update-poll-text-long.js
@@ -1,0 +1,13 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('polls', 'text', {
+      type: Sequelize.TEXT('long'),
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('polls', 'text', {
+      type: Sequelize.STRING,
+    });
+  },
+};

--- a/models.js
+++ b/models.js
@@ -13,7 +13,7 @@ const db = config.DATABASE_URL
 const PollModel = db.define(
   'polls',
   {
-    text: { type: Sequelize.STRING },
+    text: { type: Sequelize.TEXT('long') },
     owner: { type: Sequelize.STRING },
     channel: { type: Sequelize.STRING },
     titleTs: { type: Sequelize.STRING },


### PR DESCRIPTION
#### What does this PR do?
Changes `text` type from `polls` model in database from `varchar 255` to `postgress text` preventing it from throwing when the slash command are very long

#### Type of change
- Bug fix