### PR TITLE
Use icon_emoji as slack bot image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SlackPoll
+
 Slack bot that helps users to do polling and allows users.
 
 ![SlackPoll](/static/sample.png)
@@ -18,8 +19,11 @@ To integrate into your Slack workspace, you will need to create a [Slack App](ht
 - OAuth & Permissions > Scopes > Add permissions [`chat:write:bot`, `commands`, `reactions:write`]
 
 Initialize `.env` file with
+
 - `DATABASE_URL` (if SQLite ignore `DATABASE_URL`)
 - `SLACK_VERIFICATION_TOKEN`, `SLACK_ACCESS_TOKEN` from your SlackApp
+- (Optional) You can use `icon_emoji` list as a comma separed list with
+  `SLACK_MESSAGE_ICON_EMOJIS` env var to change the slack bot profile image, if you define more than one it will pick one randomly. iex: `one,two,three`
 
 ```
 cp .env.example .env
@@ -29,12 +33,13 @@ npm start
 ## Development
 
 Generating Migrations
+
 ```sh
 ./node_modules/.bin/sequelize migration:generate --name <migration_name>
 ```
 
 Running daemon
+
 ```sh
 npm run dev
 ```
-

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To integrate into your Slack workspace, you will need to create a [Slack App](ht
 
 Initialize `.env` file with
 - `DATABASE_URL` (if SQLite ignore `DATABASE_URL`)
-- `SLACK_VERIFICATION_TOKEN`, `SLACK_VERIFICATION_TOKEN` from your SlackApp
+- `SLACK_VERIFICATION_TOKEN`, `SLACK_ACCESS_TOKEN` from your SlackApp
 
 ```
 cp .env.example .env
@@ -30,7 +30,7 @@ npm start
 
 Generating Migrations
 ```sh
-node_modules/.bin/sequelize migration:generate --name <migration_name>
+./node_modules/.bin/sequelize migration:generate --name <migration_name>
 ```
 
 Running daemon

--- a/config.js
+++ b/config.js
@@ -7,7 +7,8 @@ const {
   SLACK_BASE_URL = 'https://slack.com/api',
   DATABASE_URL,
   SLACK_VERIFICATION_TOKEN,
-  SLACK_ACCESS_TOKEN
+  SLACK_ACCESS_TOKEN,
+  SLACK_MESSAGE_ICON_EMOJIS = 'bar_chart'
 } = process.env;
 
 const defaults = {
@@ -29,5 +30,6 @@ module.exports = {
   SLACK_BASE_URL,
   DATABASE_URL,
   SLACK_VERIFICATION_TOKEN,
-  SLACK_ACCESS_TOKEN
+  SLACK_ACCESS_TOKEN,
+  SLACK_MESSAGE_ICON_EMOJIS
 };

--- a/controller.js
+++ b/controller.js
@@ -6,6 +6,12 @@ const utils = require('./utils');
 const service = require('./service');
 const constants = require('./constants');
 
+// Format emojis with :: that slack needs to print an emojit
+// It will pick a random emoji from list on pollPost
+const iconEmojis = config.SLACK_MESSAGE_ICON_EMOJIS.split(',').map(
+  emoji => `:${emoji}:`
+);
+
 // Base message template from https://api.slack.com/docs/message-formatting
 function messageTemplate(messageData) {
   const { pollTitle, pollOptions, items, currentPoll, emojis } = messageData;
@@ -108,6 +114,7 @@ async function pollPost(req, res) {
     */
 
     const titleResponse = await slackApi('chat.postMessage', 'POST', {
+      icon_emoji: iconEmojis[Math.floor(Math.random() * iconEmojis.length)],
       ...messageTemplate({
         pollTitle,
         pollOptions,


### PR DESCRIPTION
#### What does this PR do?
Add support for `icon_emoji` as slack bot profile

It adds SLACK_MESSAGE_ICON_EMOJIS env var, see README.md
