### PR TITLE
fix env vars reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Initialize `.env` file with
 
 - `DATABASE_URL` (if SQLite ignore `DATABASE_URL`)
 - `SLACK_VERIFICATION_TOKEN`, `SLACK_ACCESS_TOKEN` from your SlackApp
-- (Optional) You can define the poll display name in slack via `SLACK_APP_DISPLAY_NAME` _(default: <span style="color:#ffd100">#ffd100</span>)_
-- (Optional) You can define the poll side color from the message via `SLACK_MESSAGE_BAR_COLOR` _(default: Yellow Poll)_
+- (Optional) You can define the poll display name in slack via `SLACK_MESSAGE_BAR_COLOR` _(default: <span style="color:#ffd100">#ffd100</span>)_
+- (Optional) You can define the poll side color from the message via `SLACK_APP_DISPLAY_NAME` _(default: Yellow Poll)_
 - (Optional) You can use `icon_emoji` list as a comma separed list with
   `SLACK_MESSAGE_ICON_EMOJIS` env var to change the slack bot profile image, if you define more than one it will pick one randomly. iex: `one,two,three`. _(default: :bar_chart:)_
 


### PR DESCRIPTION
#### What does this PR do?
Fix bad reference in README for the env vars (`SLACK_MESSAGE_BAR_COLOR `, `SLACK_APP_DISPLAY_NAME `)